### PR TITLE
feat: Add support for multiple calendar management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-switch": "^1.2.5",
         "@radix-ui/react-tabs": "^1.1.12",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2435,6 +2436,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.5.tgz",
+      "integrity": "sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
@@ -2539,6 +2569,21 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-tabs": "^1.1.12",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/api/calendar/events/route.ts
+++ b/src/app/api/calendar/events/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { AuthService } from '@/services/auth-service';
 import { GoogleCalendarService } from '@/services/google-calendar-service';
+import { adminDb } from '@/config/firebase-admin';
 
 export async function GET(request: NextRequest) {
   try {
@@ -11,19 +12,87 @@ export async function GET(request: NextRequest) {
     }
 
     const searchParams = request.nextUrl.searchParams;
-    const calendarId = searchParams.get('calendarId') || 'primary';
+    const specificCalendarId = searchParams.get('calendarId');
     const timeMin = searchParams.get('timeMin');
     const timeMax = searchParams.get('timeMax');
     const maxResults = searchParams.get('maxResults');
 
     const calendarService = new GoogleCalendarService(user.email);
-    const events = await calendarService.listEvents(calendarId, {
-      timeMin: timeMin || undefined,
-      timeMax: timeMax || undefined,
-      maxResults: maxResults ? parseInt(maxResults) : undefined,
+
+    // If a specific calendar is requested, use the original behavior
+    if (specificCalendarId) {
+      const events = await calendarService.listEvents(specificCalendarId, {
+        timeMin: timeMin || undefined,
+        timeMax: timeMax || undefined,
+        maxResults: maxResults ? parseInt(maxResults) : undefined,
+      });
+
+      return NextResponse.json({ events });
+    }
+
+    // Otherwise, fetch from all selected calendars
+    let calendarIds = ['primary']; // Default fallback
+
+    try {
+      const selectedCalendarsDoc = await adminDb
+        .collection('users')
+        .doc(user.email)
+        .collection('calendars')
+        .doc('selected')
+        .get();
+
+      if (selectedCalendarsDoc.exists) {
+        const data = selectedCalendarsDoc.data();
+        const selectedCalendars = data?.calendars || [];
+        const enabledCalendars = selectedCalendars.filter((cal: any) => cal.enabled);
+        
+        if (enabledCalendars.length > 0) {
+          calendarIds = enabledCalendars.map((cal: any) => cal.id);
+        }
+      }
+    } catch (error) {
+      console.warn('Error fetching selected calendars, using primary:', error);
+    }
+
+    // Fetch events from all selected calendars
+    const allEvents = [];
+    const maxPerCalendar = maxResults ? Math.ceil(parseInt(maxResults) / calendarIds.length) : 50;
+
+    for (const calendarId of calendarIds) {
+      try {
+        const events = await calendarService.listEvents(calendarId, {
+          timeMin: timeMin || undefined,
+          timeMax: timeMax || undefined,
+          maxResults: maxPerCalendar,
+        });
+
+        // Add calendar info to each event
+        const eventsWithCalendar = events.map((event: any) => ({
+          ...event,
+          calendarId,
+        }));
+
+        allEvents.push(...eventsWithCalendar);
+      } catch (error) {
+        console.warn(`Error fetching events from calendar ${calendarId}:`, error);
+        // Continue with other calendars
+      }
+    }
+
+    // Sort events by start time
+    allEvents.sort((a, b) => {
+      const aStart = a.start?.dateTime || a.start?.date || '';
+      const bStart = b.start?.dateTime || b.start?.date || '';
+      return new Date(aStart).getTime() - new Date(bStart).getTime();
     });
 
-    return NextResponse.json({ events });
+    // Apply global maxResults limit
+    const limitedEvents = maxResults ? allEvents.slice(0, parseInt(maxResults)) : allEvents;
+
+    return NextResponse.json({ 
+      events: limitedEvents,
+      calendarsUsed: calendarIds.length,
+    });
   } catch (error) {
     console.error('Error fetching events:', error);
     return NextResponse.json(

--- a/src/app/api/calendar/list/route.ts
+++ b/src/app/api/calendar/list/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { AuthService } from '@/services/auth-service';
+import { GoogleCalendarService } from '@/services/google-calendar-service';
+
+export async function GET() {
+  try {
+    const user = await AuthService.getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const calendarService = new GoogleCalendarService(user.email);
+    const calendars = await calendarService.listCalendars();
+
+    // Filter and format calendar data
+    const formattedCalendars = calendars.map((calendar) => ({
+      id: calendar.id,
+      summary: calendar.summary,
+      description: calendar.description,
+      primary: calendar.primary || false,
+      accessRole: calendar.accessRole,
+      backgroundColor: calendar.backgroundColor,
+      foregroundColor: calendar.foregroundColor,
+    }));
+
+    return NextResponse.json({ calendars: formattedCalendars });
+  } catch (error) {
+    console.error('Error listing calendars:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch calendars' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/calendar/selected/route.ts
+++ b/src/app/api/calendar/selected/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { AuthService } from '@/services/auth-service';
+import { adminDb } from '@/config/firebase-admin';
+import { FieldValue } from 'firebase-admin/firestore';
+
+interface SelectedCalendar {
+  id: string;
+  summary: string;
+  description?: string;
+  primary?: boolean;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  enabled: boolean;
+  label?: string; // User-defined label like "Work" or "Personal"
+}
+
+export async function GET() {
+  try {
+    const user = await AuthService.getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const selectedCalendarsDoc = await adminDb
+      .collection('users')
+      .doc(user.email)
+      .collection('calendars')
+      .doc('selected')
+      .get();
+
+    if (!selectedCalendarsDoc.exists) {
+      // Return default configuration with primary calendar
+      return NextResponse.json({
+        calendars: [],
+        hasConfiguration: false,
+      });
+    }
+
+    const data = selectedCalendarsDoc.data();
+    return NextResponse.json({
+      calendars: data?.calendars || [],
+      hasConfiguration: true,
+      updatedAt: data?.updatedAt || null,
+    });
+  } catch (error) {
+    console.error('Error fetching selected calendars:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch selected calendars' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function PUT(request: NextRequest) {
+  try {
+    const user = await AuthService.getCurrentUser();
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { calendars } = body;
+
+    if (!Array.isArray(calendars)) {
+      return NextResponse.json(
+        { error: 'Invalid calendars data' },
+        { status: 400 }
+      );
+    }
+
+    // Validate calendar objects
+    for (const calendar of calendars) {
+      if (!calendar.id || typeof calendar.enabled !== 'boolean') {
+        return NextResponse.json(
+          { error: 'Invalid calendar object' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Ensure at least one calendar is enabled
+    const enabledCalendars = calendars.filter((cal) => cal.enabled);
+    if (enabledCalendars.length === 0) {
+      return NextResponse.json(
+        { error: 'At least one calendar must be enabled' },
+        { status: 400 }
+      );
+    }
+
+    const selectedCalendarsRef = adminDb
+      .collection('users')
+      .doc(user.email)
+      .collection('calendars')
+      .doc('selected');
+
+    const selectedCalendarsDoc = await selectedCalendarsRef.get();
+    const now = FieldValue.serverTimestamp();
+
+    const calendarData = {
+      calendars,
+      updatedAt: now,
+    };
+
+    if (!selectedCalendarsDoc.exists) {
+      await selectedCalendarsRef.set({
+        ...calendarData,
+        createdAt: now,
+        version: 1,
+      });
+    } else {
+      await selectedCalendarsRef.update({
+        ...calendarData,
+        version: FieldValue.increment(1),
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      enabledCount: enabledCalendars.length,
+    });
+  } catch (error) {
+    console.error('Error updating selected calendars:', error);
+    return NextResponse.json(
+      { error: 'Failed to update selected calendars' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/preferences/page.tsx
+++ b/src/app/preferences/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from '@/contexts/auth-context';
 import { PreferencesForm } from '@/components/preferences/preferences-form';
+import { CalendarManagement } from '@/components/preferences/calendar-management';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { useEffect } from 'react';
@@ -67,7 +68,9 @@ export default function PreferencesPage() {
         </div>
       </header>
 
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <CalendarManagement />
+
         <Card className="p-6">
           <div className="mb-6">
             <h2 className="text-xl font-semibold mb-2">

--- a/src/components/preferences/calendar-management.tsx
+++ b/src/components/preferences/calendar-management.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Badge } from '@/components/ui/badge';
+import { Loader2, Calendar, Save, RefreshCw, Check } from 'lucide-react';
+import { toast } from 'sonner';
+import { motion } from 'framer-motion';
+
+interface Calendar {
+  id: string;
+  summary: string;
+  description?: string;
+  primary?: boolean;
+  backgroundColor?: string;
+  foregroundColor?: string;
+  accessRole?: string;
+}
+
+interface SelectedCalendar extends Calendar {
+  enabled: boolean;
+  label?: string;
+}
+
+export function CalendarManagement() {
+  const [availableCalendars, setAvailableCalendars] = useState<Calendar[]>([]);
+  const [selectedCalendars, setSelectedCalendars] = useState<SelectedCalendar[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  useEffect(() => {
+    loadCalendars();
+  }, []);
+
+  const loadCalendars = async () => {
+    setIsLoading(true);
+    try {
+      // Load available calendars
+      const availableResponse = await fetch('/api/calendar/list');
+      if (!availableResponse.ok) throw new Error('Failed to fetch calendars');
+      const availableData = await availableResponse.json();
+
+      // Load selected calendars
+      const selectedResponse = await fetch('/api/calendar/selected');
+      if (!selectedResponse.ok) throw new Error('Failed to fetch selected calendars');
+      const selectedData = await selectedResponse.json();
+
+      setAvailableCalendars(availableData.calendars || []);
+
+      // If user has no configuration, create default with primary calendar
+      if (!selectedData.hasConfiguration && availableData.calendars.length > 0) {
+        const primaryCalendar = availableData.calendars.find((cal: Calendar) => cal.primary);
+        const defaultCalendar = primaryCalendar || availableData.calendars[0];
+        
+        setSelectedCalendars([{
+          ...defaultCalendar,
+          enabled: true,
+          label: defaultCalendar.primary ? 'Primary' : 'Main Calendar',
+        }]);
+        setHasUnsavedChanges(true);
+      } else {
+        setSelectedCalendars(selectedData.calendars || []);
+      }
+    } catch (error) {
+      console.error('Error loading calendars:', error);
+      toast.error('Failed to load calendars');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const refreshCalendars = async () => {
+    setIsRefreshing(true);
+    try {
+      const response = await fetch('/api/calendar/list');
+      if (!response.ok) throw new Error('Failed to refresh calendars');
+      const data = await response.json();
+      setAvailableCalendars(data.calendars || []);
+      toast.success('Calendars refreshed');
+    } catch (error) {
+      console.error('Error refreshing calendars:', error);
+      toast.error('Failed to refresh calendars');
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const toggleCalendar = (calendarId: string) => {
+    setSelectedCalendars(prev => {
+      const existing = prev.find(cal => cal.id === calendarId);
+      
+      if (existing) {
+        // Toggle existing calendar
+        const updated = prev.map(cal => 
+          cal.id === calendarId ? { ...cal, enabled: !cal.enabled } : cal
+        );
+        
+        // Ensure at least one calendar is enabled
+        const enabledCount = updated.filter(cal => cal.enabled).length;
+        if (enabledCount === 0) {
+          toast.error('At least one calendar must be enabled');
+          return prev;
+        }
+        
+        setHasUnsavedChanges(true);
+        return updated;
+      } else {
+        // Add new calendar
+        const calendar = availableCalendars.find(cal => cal.id === calendarId);
+        if (!calendar) return prev;
+        
+        const newCalendar: SelectedCalendar = {
+          ...calendar,
+          enabled: true,
+          label: calendar.primary ? 'Primary' : calendar.summary,
+        };
+        
+        setHasUnsavedChanges(true);
+        return [...prev, newCalendar];
+      }
+    });
+  };
+
+  const updateCalendarLabel = (calendarId: string, label: string) => {
+    setSelectedCalendars(prev => 
+      prev.map(cal => 
+        cal.id === calendarId ? { ...cal, label } : cal
+      )
+    );
+    setHasUnsavedChanges(true);
+  };
+
+  const saveCalendars = async () => {
+    setIsSaving(true);
+    try {
+      const response = await fetch('/api/calendar/selected', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ calendars: selectedCalendars }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to save calendars');
+      }
+
+      const result = await response.json();
+      toast.success(`Saved ${result.enabledCount} calendar(s)`);
+      setHasUnsavedChanges(false);
+    } catch (error) {
+      console.error('Error saving calendars:', error);
+      toast.error(error instanceof Error ? error.message : 'Failed to save calendars');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card className="p-6">
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin mr-2" />
+          <span>Loading calendars...</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const enabledCount = selectedCalendars.filter(cal => cal.enabled).length;
+
+  return (
+    <Card className="p-6">
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold flex items-center gap-2">
+              <Calendar className="h-5 w-5" />
+              Calendar Management
+            </h3>
+            <p className="text-sm text-muted-foreground mt-1">
+              Select which calendars to use for scheduling meetings. At least one calendar is required.
+            </p>
+          </div>
+          <Button
+            onClick={refreshCalendars}
+            disabled={isRefreshing}
+            variant="outline"
+            size="sm"
+          >
+            {isRefreshing ? (
+              <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            ) : (
+              <RefreshCw className="h-4 w-4 mr-2" />
+            )}
+            Refresh
+          </Button>
+        </div>
+
+        <div className="space-y-4">
+          {availableCalendars.map((calendar) => {
+            const selected = selectedCalendars.find(cal => cal.id === calendar.id);
+            const isEnabled = selected?.enabled || false;
+
+            return (
+              <motion.div
+                key={calendar.id}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className={`border rounded-lg p-4 transition-all ${
+                  isEnabled ? 'bg-blue-50 border-blue-200' : 'bg-gray-50 border-gray-200'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 space-y-3">
+                    <div className="flex items-center gap-3">
+                      <Switch
+                        checked={isEnabled}
+                        onCheckedChange={() => toggleCalendar(calendar.id)}
+                      />
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <h4 className="font-medium">{calendar.summary}</h4>
+                          {calendar.primary && (
+                            <Badge variant="secondary" className="text-xs">
+                              Primary
+                            </Badge>
+                          )}
+                        </div>
+                        {calendar.description && (
+                          <p className="text-sm text-muted-foreground">
+                            {calendar.description}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    {isEnabled && (
+                      <motion.div
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: 'auto' }}
+                        className="ml-8 space-y-2"
+                      >
+                        <Label htmlFor={`label-${calendar.id}`} className="text-sm">
+                          Display Label
+                        </Label>
+                        <Input
+                          id={`label-${calendar.id}`}
+                          value={selected?.label || ''}
+                          onChange={(e) => updateCalendarLabel(calendar.id, e.target.value)}
+                          placeholder="e.g., Work, Personal, etc."
+                          className="max-w-xs"
+                        />
+                      </motion.div>
+                    )}
+                  </div>
+
+                  {calendar.backgroundColor && (
+                    <div
+                      className="w-4 h-4 rounded border border-gray-300"
+                      style={{ backgroundColor: calendar.backgroundColor }}
+                      title="Calendar color"
+                    />
+                  )}
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+
+        <div className="flex items-center justify-between pt-4 border-t">
+          <div className="text-sm text-muted-foreground">
+            {enabledCount} calendar{enabledCount !== 1 ? 's' : ''} enabled
+            {hasUnsavedChanges && (
+              <span className="ml-2 text-orange-600">• Unsaved changes</span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            {!hasUnsavedChanges && enabledCount > 0 && (
+              <motion.span
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="text-sm text-green-600 flex items-center gap-1"
+              >
+                <Check className="h-3 w-3" />
+                Saved
+              </motion.span>
+            )}
+            <Button
+              onClick={saveCalendars}
+              disabled={isSaving || !hasUnsavedChanges}
+              size="sm"
+            >
+              {isSaving ? (
+                <Loader2 className="h-4 w-4 animate-spin mr-2" />
+              ) : (
+                <Save className="h-4 w-4 mr-2" />
+              )}
+              Save Changes
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        destructive:
+          "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
+        outline: "text-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }


### PR DESCRIPTION
Implements multi-calendar support allowing users to connect both work and personal calendars.

## Summary
- Add calendar management API endpoints
- Create calendar selection UI in preferences
- Update dashboard to show multi-calendar support
- Maintain backward compatibility with existing setups

Closes #5

Generated with [Claude Code](https://claude.ai/code)